### PR TITLE
allow string type as countryCode parameter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -153,7 +153,7 @@ const headers = {
 };
 
 const validateVat = async (
-  countryCode: CountryCodes,
+  countryCode: CountryCodes | string,
   vatNumber: string,
   serviceUrl: string = VAT_SERVICE_URL
 ): Promise<ViesValidationResponse> => {


### PR DESCRIPTION
Now i have to do the following:

```
const validationInfo = await validateVat(
    data.countryCode as CountryCodes,
    data.vatNumber
  );
```